### PR TITLE
Update BaseApp

### DIFF
--- a/com.opera.Opera.yaml
+++ b/com.opera.Opera.yaml
@@ -3,7 +3,7 @@ runtime: org.freedesktop.Platform
 runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 base: org.chromium.Chromium.BaseApp
-base-version: '22.08'
+base-version: '23.08'
 command: opera
 separate-locales: false
 finish-args:


### PR DESCRIPTION
You are currently using version 22.08 of the BaseApp while using version 23.08 of the Freedesktop Runtime.