### PR TITLE
Update opera

### DIFF
--- a/apply_extra.sh
+++ b/apply_extra.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/sh
+
+set -e
+
+bsdtar --to-stdout -xf opera.deb 'data.tar*' |
+  bsdtar -xf - \
+     --strip-components=4 \
+     --include='./usr/lib/x86_64-linux-gnu/opera' 
+rm opera.deb
+
+if [ -f "libffmpeg.zip" ]; then
+  unzip libffmpeg.zip
+  rm libffmpeg.zip
+  mkdir opera/lib_extra
+  mv libffmpeg.so opera/lib_extra
+fi

--- a/com.opera.Opera.metainfo.xml
+++ b/com.opera.Opera.metainfo.xml
@@ -53,24 +53,13 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="111.0.5168.25" date="2024-06-12">
-      <description></description>
-    </release>
-    <release version="110.0.5130.66" date="2024-06-04">
-      <description/>
-    </release>
-    <release version="110.0.5130.64" date="2024-06-04">
-      <description/>
-    </release>
-    <release version="110.0.5130.49" date="2024-05-28">
-      <description/>
-    </release>
-    <release version="110.0.5130.39" date="2024-05-24">
-      <description/>
-    </release>
-    <release version="110.0.5130.35" date="2024-05-22">
-      <description/>
-    </release>
+    <release version="111.0.5168.55" date="2024-07-01"/>
+    <release version="111.0.5168.25" date="2024-06-12"/>
+    <release version="110.0.5130.66" date="2024-06-04"/>
+    <release version="110.0.5130.64" date="2024-06-04"/>
+    <release version="110.0.5130.49" date="2024-05-28"/>
+    <release version="110.0.5130.39" date="2024-05-24"/>
+    <release version="110.0.5130.35" date="2024-05-22"/>
     <release version="110.0.5130.23" date="2024-05-14">
       <url type="details">https://blogs.opera.com/desktop/changelog-for-110/</url>
       <description>

--- a/com.opera.Opera.yaml
+++ b/com.opera.Opera.yaml
@@ -111,9 +111,9 @@ modules:
         filename: opera.deb
         only-arches:
           - x86_64
-        url: https://get.geo.opera.com/pub/opera/desktop/111.0.5168.25/linux/opera-stable_111.0.5168.25_amd64.deb
-        sha256: 812564281f95523d98a60bc45f227daff400d17a17e1a6fd815bbf7d34e0bf49
-        size: 110244468
+        url: https://get.geo.opera.com/pub/opera/desktop/111.0.5168.55/linux/opera-stable_111.0.5168.55_amd64.deb
+        sha256: 22b8f65f5a0d2e400a3abf27916cea8bb4967a00d21e60f7ae63837acfbdf657
+        size: 110217064
         x-checker-data:
           is-main-source: true
           type: anitya

--- a/com.opera.Opera.yaml
+++ b/com.opera.Opera.yaml
@@ -83,12 +83,13 @@ modules:
   - name: opera-codecs
     buildsystem: simple
     build-commands:
-      - mkdir -p /app/opera/lib_extra
-      - install -Dm 644 -t /app/opera/lib_extra libffmpeg.so
+      - pwd # extra data is not available at this time
     sources:
-      - type: archive
+      - type: extra-data
+        filename: libffmpeg.zip
         url: https://github.com/Ld-Hagen/nwjs-ffmpeg-prebuilt/releases/download/nwjs-ffmpeg-0.88.0/0.88.0-linux-x64.zip
         sha256: a8bcc460b892ce6efbedc9b2abd37308dfca507e600b6319b0a7107b2dbaf754
+        size: 4912235
         x-checker-data:
           type: json
           url: https://api.github.com/repos/Ld-Hagen/nwjs-ffmpeg-prebuilt/releases/latest
@@ -98,29 +99,31 @@ modules:
   - name: opera
     buildsystem: simple
     build-commands:
-      - mkdir -p /app/opera /app/tmp-install/data
-      - bsdtar -xf opera.deb -C /app/tmp-install
-      - bsdtar -xf /app/tmp-install/data.tar.xz -C /app/tmp-install/data
-      - cp -rl /app/tmp-install/data/usr/lib/x86_64-linux-gnu/opera /app
-      - rm -rf /app/tmp-install opera.deb
-      - install -Dm 644 com.opera.Opera.desktop /app/share/applications/com.opera.Opera.desktop
-      - install -Dm 644 Opera_2015_icon.svg /app/share/icons/hicolor/scalable/apps/com.opera.Opera.svg
-      - install -Dm 755 opera.sh /app/bin/opera
-      - install -Dm 644 -t /app/etc cobalt.ini
-      - install -Dm 644 -t /app/share/metainfo com.opera.Opera.metainfo.xml
+      - install -Dm 644 cobalt.ini ${FLATPAK_DEST}/etc
+      - install -Dm 644 ${FLATPAK_ID}.metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml
+      - install -Dm 644 ${FLATPAK_ID}.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
+      - install -Dm 644 Opera_2015_icon.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
+      - install -Dm 755 opera.sh ${FLATPAK_DEST}/bin/opera
+      - install -Dm 755 apply_extra.sh ${FLATPAK_DEST}/bin/apply_extra
+      - ln -s ${FLATPAK_DEST}/extra/opera ${FLATPAK_DEST}/opera
     sources:
-      - type: file
+      - type: extra-data
+        filename: opera.deb
+        only-arches:
+          - x86_64
         url: https://get.geo.opera.com/pub/opera/desktop/111.0.5168.25/linux/opera-stable_111.0.5168.25_amd64.deb
         sha256: 812564281f95523d98a60bc45f227daff400d17a17e1a6fd815bbf7d34e0bf49
-        dest-filename: opera.deb
-        only-arches: [x86_64]
+        size: 110244468
         x-checker-data:
+          is-main-source: true
           type: anitya
           project-id: 7242
           stable-only: true
           url-template: https://get.geo.opera.com/pub/opera/desktop/$version/linux/opera-stable_${version}_amd64.deb
       - type: file
         path: cobalt.ini
+      - type: file
+        path: apply_extra.sh
       - type: file
         path: com.opera.Opera.metainfo.xml
       - type: file

--- a/com.opera.Opera.yaml
+++ b/com.opera.Opera.yaml
@@ -130,7 +130,5 @@ modules:
         path: Opera_2015_icon.svg
       - type: file
         path: com.opera.Opera.desktop
-      - type: script
-        dest-filename: opera.sh
-        commands:
-          - exec cobalt "$@"
+      - type: file
+        path: opera.sh

--- a/opera.sh
+++ b/opera.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/bash
+
+# Merge the policies with the host ones.
+policy_root=/etc/opt/opera/policies
+
+for policy_type in managed recommended enrollment; do
+  policy_dir="$policy_root/$policy_type"
+  mkdir -p "$policy_dir"
+
+  if [[ -d "/run/host/$policy_root/$policy_type" ]]; then
+    find "/run/host/$policy_root/$policy_type" -type f -name '*' \
+      -maxdepth 1 -name '*.json' -type f \
+      -exec ln -sf '{}' "$policy_root/$policy_type" \;
+  fi
+done
+
+exec cobalt "$@"


### PR DESCRIPTION
Changes:
- opera: Update opera.deb to 111.0.5168.55
- support for host policy files
- change data type to hopefully re-enable automatic updates

Closes #110.